### PR TITLE
[#19] Bump up spring dependencies version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ buildscript {
 allprojects {
     group = "com.navercorp.eventeria"
     version = "1.1.1-SNAPSHOT"
+
+    // https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs.add("-parameters")
+    }
 }
 
 subprojects {
@@ -27,10 +32,10 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_17
 
     ext {
-        CLOUD_EVENTS_VERSION = "2.4.2"
-        SPRING_BOOT_VERSION = "3.0.5"
-        SPRING_CLOUD_VERSION = "4.0.1"
-        SPRING_CLOUD_INTEGRATION_KAFKA = "6.0.4"
+        CLOUD_EVENTS_VERSION = "2.5.0"
+        SPRING_BOOT_VERSION = "3.2.1"
+        SPRING_CLOUD_VERSION = "4.1.0"
+        SPRING_CLOUD_INTEGRATION_KAFKA = "6.2.1"
 
         JQWIK_VERSION = "1.7.0"
     }

--- a/eventeria-messaging-kafka/src/test/java/com/navercorp/eventeria/messaging/kafka/CloudEventKafkaTest.java
+++ b/eventeria-messaging-kafka/src/test/java/com/navercorp/eventeria/messaging/kafka/CloudEventKafkaTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
@@ -37,6 +38,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.EmbeddedKafkaZKBroker;
 
 import net.jqwik.api.Example;
 import net.jqwik.api.ForAll;
@@ -69,11 +71,15 @@ class CloudEventKafkaTest {
 	private static final EmbeddedKafkaBroker BROKER;
 
 	static {
-		BROKER = new EmbeddedKafkaBroker(1, true, 1)
+		BROKER = new EmbeddedKafkaZKBroker(1, true, 1)
 			.kafkaPorts(0)
-			.brokerProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), (short)1)
-			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), (short)1)
-			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), 1);
+			.brokerProperties(
+				Map.of(
+					KafkaConfig.OffsetsTopicReplicationFactorProp(), "1",
+					KafkaConfig.TransactionsTopicReplicationFactorProp(), "1",
+					KafkaConfig.TransactionsTopicMinISRProp(), "1"
+				)
+			);
 		BROKER.afterPropertiesSet();
 	}
 

--- a/eventeria-messaging-spring-integration/src/main/java/com/navercorp/eventeria/messaging/spring/integration/dsl/MessageBatchSubscriberIntegrationAdapter.java
+++ b/eventeria-messaging-spring-integration/src/main/java/com/navercorp/eventeria/messaging/spring/integration/dsl/MessageBatchSubscriberIntegrationAdapter.java
@@ -66,7 +66,7 @@ public class MessageBatchSubscriberIntegrationAdapter extends IntegrationFlowAda
 	protected IntegrationFlowDefinition<?> buildFlow() {
 		return IntegrationFlow.from(this.getInputSubscribableChannel())
 			.enrichHeaders(eh -> eh.correlationId(UUID.randomUUID()))
-			.split(sp -> sp.applySequence(true).get())
+			.splitWith(sp -> sp.applySequence(true).getObject())
 			.filter(CloudEvent.class, this.getCloudEventFilter()::accept)
 			.transform(CloudEvent.class, this.getMessageConverter()::convert)
 			.aggregate(sp -> sp.expireGroupsUponCompletion(true))

--- a/spring-boot-eventeria/src/test/java/com/navercorp/spring/boot/eventeria/SpringBootContextLoadTest.java
+++ b/spring-boot-eventeria/src/test/java/com/navercorp/spring/boot/eventeria/SpringBootContextLoadTest.java
@@ -1,0 +1,14 @@
+package com.navercorp.spring.boot.eventeria;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.navercorp.spring.boot.eventeria.config.MessageConfiguration;
+
+@SpringBootTest(classes = MessageConfiguration.class)
+public class SpringBootContextLoadTest {
+
+	@Test
+	void contextLoads() {
+	}
+}


### PR DESCRIPTION
resolves #19

- bump up versions
- add test to check loading spring context successfully

target | prev | next
-- | -- | --
cloudevents sdk-java | 2.4.2 | 2.5.0
spring-boot | 3.0.5 | 3.2.1
spring-cloud-stream | 4.0.1 | 4.1.0
spring-integration-kafka | 6.0.4 | 6.2.1