### PR TITLE
Add guide applications for spring-boot-eventeria

### DIFF
--- a/guide-projects/spring-boot-eventeria-guide/build.gradle
+++ b/guide-projects/spring-boot-eventeria-guide/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id "eventeria.java-conventions"
+    id "eventeria.verification-conventions"
+    id "eventeria.spring-dependency-management-conventions"
+}
+
+dependencies {
+    implementation project(":spring-boot-eventeria")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // for embedded kafka
+    implementation("org.springframework.kafka:spring-kafka-test")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/guide-projects/spring-boot-eventeria-guide/lombok.config
+++ b/guide-projects/spring-boot-eventeria-guide/lombok.config
@@ -1,0 +1,3 @@
+lombok.anyConstructor.addConstructorProperties=true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/SpringBootEventeriaGuideApplication.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/SpringBootEventeriaGuideApplication.java
@@ -1,0 +1,11 @@
+package com.navercorp.eventeria.guide.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBootEventeriaGuideApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(SpringBootEventeriaGuideApplication.class, args);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/EmbeddedKafkaHolder.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/EmbeddedKafkaHolder.java
@@ -1,0 +1,45 @@
+package com.navercorp.eventeria.guide.boot.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.EmbeddedKafkaZKBroker;
+
+public final class EmbeddedKafkaHolder implements InitializingBean {
+
+	private static final EmbeddedKafkaBroker embeddedKafka = new EmbeddedKafkaZKBroker(1, false)
+		.brokerListProperty("spring.kafka.bootstrap-servers");
+
+	private static boolean started;
+
+	private final List<String> topics;
+
+	EmbeddedKafkaHolder(List<String> topics) {
+		super();
+		this.topics = topics;
+	}
+
+	public static EmbeddedKafkaBroker getEmbeddedKafka() {
+		if (!started) {
+			try {
+				embeddedKafka.afterPropertiesSet();
+			} catch (Exception e) {
+				throw new KafkaException("Embedded broker failed to start", e);
+			}
+			started = true;
+		}
+		return embeddedKafka;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		embeddedKafka.afterPropertiesSet();
+		started = true;
+
+		embeddedKafka.addTopics(
+			topics.toArray(String[]::new)
+		);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/KafkaConfig.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/KafkaConfig.java
@@ -1,0 +1,27 @@
+package com.navercorp.eventeria.guide.boot.config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KafkaConfig {
+
+	@Bean("topicsMap")
+	@ConfigurationProperties(prefix = "topics")
+	Map<String, String> topicsMap() {
+		return new HashMap<>();
+	}
+
+	@Bean
+	EmbeddedKafkaHolder embeddedKafkaHolder(
+		@Qualifier("topicsMap") Map<String, String> topicsMap
+	) {
+		return new EmbeddedKafkaHolder(List.copyOf(topicsMap.values()));
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/MessageConfig.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/config/MessageConfig.java
@@ -1,0 +1,93 @@
+package com.navercorp.eventeria.guide.boot.config;
+
+import java.util.function.Function;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.binding.SubscribableChannelBindingTargetFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.cloudevents.core.provider.EventFormatProvider;
+import io.cloudevents.jackson.JsonFormat;
+import lombok.RequiredArgsConstructor;
+
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.NotifyToSubscribers;
+import com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent;
+import com.navercorp.eventeria.messaging.contract.Message;
+import com.navercorp.eventeria.messaging.contract.cloudevents.serializer.CloudEventMessageReaderWriter;
+import com.navercorp.eventeria.messaging.contract.serializer.MessageSerializerDeserializer;
+import com.navercorp.eventeria.messaging.jackson.serializer.JacksonMessageSerializer;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.ChannelBindable;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.ChannelBinder;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.DefaultChannelBinder;
+import com.navercorp.eventeria.messaging.typealias.CloudEventMessageTypeAliasMapper;
+import com.navercorp.spring.boot.eventeria.support.FunctionalBindingSupports;
+
+@Configuration
+@RequiredArgsConstructor
+public class MessageConfig {
+
+	private final ObjectMapper objectMapper;
+
+	static {
+		EventFormatProvider.getInstance()
+			.registerFormat(
+				new JsonFormat()
+					.withForceExtensionNameLowerCaseDeserialization()
+					.withForceIgnoreInvalidExtensionNameDeserialization()
+			);
+	}
+
+	@Bean
+	MessageSerializerDeserializer messageSerializerDeserializer() {
+		return new JacksonMessageSerializer(objectMapper);
+	}
+
+	@Bean
+	CloudEventMessageTypeAliasMapper cloudEventMessageTypeAliasMapper() {
+		CloudEventMessageTypeAliasMapper typeAliasMapper = new CloudEventMessageTypeAliasMapper();
+
+		typeAliasMapper.addCompatibleTypeAlias(
+			PostCreatedEvent.class,
+			"com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent"
+		);
+
+		typeAliasMapper.addCompatibleTypeAlias(
+			NotifyToSubscribers.class,
+			"com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand$NotifyToSubscribers"
+		);
+
+		return typeAliasMapper;
+	}
+
+	@Bean
+	ChannelBindable channelBindable() {
+		return new ChannelBindable();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	ChannelBinder channelBinder(
+		SubscribableChannelBindingTargetFactory bindingTargetFactory,
+		ChannelBindable channelBindable
+	) {
+		return new DefaultChannelBinder(bindingTargetFactory, channelBindable);
+	}
+
+	/**
+	 * Consume and converts messages from messaging system to {@link Message}
+	 *
+	 * @param cloudEventMessageReaderWriter
+	 * @see #cloudEventMessageTypeAliasMapper()
+	 * @see spring.cloud.function.definition application.yml
+	 * @return type of {@link Message}
+	 */
+	@Bean
+	Function<org.springframework.messaging.Message<byte[]>, Message> transformCloudEventToMessage(
+		CloudEventMessageReaderWriter cloudEventMessageReaderWriter
+	) {
+		return FunctionalBindingSupports.convertToMessage(cloudEventMessageReaderWriter);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/controller/PostApiController.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/controller/PostApiController.java
@@ -1,0 +1,64 @@
+package com.navercorp.eventeria.guide.boot.controller;
+
+import java.time.Instant;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import com.navercorp.eventeria.guide.boot.domain.CreatePostService;
+import com.navercorp.eventeria.guide.boot.domain.Post;
+
+@RestController
+@RequiredArgsConstructor
+public class PostApiController {
+
+	private final CreatePostService createPostService;
+
+	@PostMapping("/posts/{postId}")
+	public PostResponse createPost(
+		@PathVariable long postId,
+		@RequestBody CreatePostRequest request
+	) {
+		Post post = createPostService.create(
+			Post.builder()
+				.id(postId)
+				.writerId(request.writerId())
+				.content(request.content())
+				.createdAt(Instant.now())
+				.build()
+		);
+
+		return PostResponse.builder()
+			.id(post.id())
+			.writerId(post.writerId())
+			.content(post.content())
+			.createdAt(post.createdAt())
+			.build();
+	}
+
+	public record CreatePostRequest(
+		long id,
+
+		String writerId,
+
+		String content
+	) {
+	}
+
+	@Builder
+	public record PostResponse(
+		long id,
+
+		String writerId,
+
+		String content,
+
+		Instant createdAt
+	) {
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCommandHandler.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCommandHandler.java
@@ -1,0 +1,28 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.ApplySearchIndex;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.RefreshPostRanking;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.UpdateUserStatistic;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AfterPostCommandHandler {
+
+	public void updateUserStatistic(UpdateUserStatistic command) {
+		log.info("[CONSUME][UpdateUserStatistic] {}", command);
+	}
+
+	public void refreshPostRanking(RefreshPostRanking command) {
+		log.info("[CONSUME][RefreshPostRanking] {}", command);
+	}
+
+	public void applySearchIndex(ApplySearchIndex command) {
+		log.info("[CONSUME][ApplySearchIndex] {}", command);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCreationCommand.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCreationCommand.java
@@ -1,0 +1,44 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import com.navercorp.eventeria.messaging.contract.command.AbstractCommand;
+import com.navercorp.eventeria.messaging.contract.command.Command;
+
+public sealed interface AfterPostCreationCommand extends Command {
+
+	@Override
+	default String getSourceType() {
+		return Post.class.getName();
+	}
+
+	// functional binding, concurrent
+	@Getter
+	@RequiredArgsConstructor
+	final class NotifyToSubscribers extends AbstractCommand implements AfterPostCreationCommand {
+		private final long postId;
+	}
+
+	// programmatic binding
+	@Getter
+	@RequiredArgsConstructor(staticName = "from")
+	final class UpdateUserStatistic extends AbstractCommand implements AfterPostCreationCommand {
+		private final long postId;
+		private final String writerId;
+	}
+
+	// programmatic binding
+	@Getter
+	@RequiredArgsConstructor(staticName = "from")
+	final class RefreshPostRanking extends AbstractCommand implements AfterPostCreationCommand {
+		private final long postId;
+	}
+
+	// programmatic binding
+	@Getter
+	@RequiredArgsConstructor(staticName = "from")
+	final class ApplySearchIndex extends AbstractCommand implements AfterPostCreationCommand {
+		private final long postId;
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCreationCommand.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/AfterPostCreationCommand.java
@@ -22,7 +22,7 @@ public sealed interface AfterPostCreationCommand extends Command {
 
 	// programmatic binding
 	@Getter
-	@RequiredArgsConstructor(staticName = "from")
+	@RequiredArgsConstructor(staticName = "of")
 	final class UpdateUserStatistic extends AbstractCommand implements AfterPostCreationCommand {
 		private final long postId;
 		private final String writerId;

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/CreatePostService.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/CreatePostService.java
@@ -1,0 +1,31 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.navercorp.eventeria.guide.boot.publisher.ProgrammaticBindingEventPublisher;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+
+@Service
+@RequiredArgsConstructor
+public class CreatePostService {
+
+	@Qualifier(ProgrammaticBindingEventPublisher.OUTBOUND_BEAN_NAME)
+	private final SpringMessagePublisher springMessagePublisher;
+
+	/**
+	 * publish {@link PostCreatedEvent} and return request parameter.
+	 *
+	 * @param post
+	 * @return
+	 */
+	public Post create(Post post) {
+		springMessagePublisher.publish(
+			PostCreatedEvent.from(post)
+		);
+
+		return post;
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/Post.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/Post.java
@@ -1,0 +1,17 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder
+public record Post(
+	long id,
+
+	String writerId,
+
+	String content,
+
+	Instant createdAt
+) {
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostCreatedEvent.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostCreatedEvent.java
@@ -1,0 +1,32 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import com.navercorp.eventeria.messaging.contract.event.AbstractDomainEvent;
+
+@Getter
+@ToString(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostCreatedEvent extends AbstractDomainEvent {
+
+	private long postId;
+	private String writerId;
+
+	public PostCreatedEvent(long postId, String writerId) {
+		super(String.valueOf(postId));
+		this.postId = postId;
+		this.writerId = writerId;
+	}
+
+	public static PostCreatedEvent from(Post post) {
+		return new PostCreatedEvent(post.id(), post.writerId());
+	}
+
+	@Override
+	public String getSourceType() {
+		return Post.class.getName();
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostEventHandler.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostEventHandler.java
@@ -29,7 +29,7 @@ public class PostEventHandler {
 
 		springMessagePublisher.publish(
 			List.of(
-				UpdateUserStatistic.from(event.getPostId(), event.getWriterId()),
+				UpdateUserStatistic.of(event.getPostId(), event.getWriterId()),
 				RefreshPostRanking.from(event.getPostId()),
 				ApplySearchIndex.from(event.getPostId())
 			)

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostEventHandler.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/domain/PostEventHandler.java
@@ -1,0 +1,38 @@
+package com.navercorp.eventeria.guide.boot.domain;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.ApplySearchIndex;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.RefreshPostRanking;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.UpdateUserStatistic;
+import com.navercorp.eventeria.guide.boot.publisher.ProgrammaticBindingAfterPostCommandPublisher;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEventHandler {
+
+	@Qualifier(ProgrammaticBindingAfterPostCommandPublisher.OUTBOUND_BEAN_NAME)
+	private final SpringMessagePublisher springMessagePublisher;
+
+	public void publishAfterPostCreatedCommands(
+		PostCreatedEvent event
+	) {
+		log.info("[CONSUME][Programmatic][PostCreatedEvent] {}", event);
+
+		springMessagePublisher.publish(
+			List.of(
+				UpdateUserStatistic.from(event.getPostId(), event.getWriterId()),
+				RefreshPostRanking.from(event.getPostId()),
+				ApplySearchIndex.from(event.getPostId())
+			)
+		);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/FunctionalBindingListener.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/FunctionalBindingListener.java
@@ -1,0 +1,50 @@
+package com.navercorp.eventeria.guide.boot.listener;
+
+import java.util.function.Consumer;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.NotifyToSubscribers;
+import com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent;
+import com.navercorp.eventeria.guide.boot.publisher.ProgrammaticBindingNotifyCommandPublisher;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+
+/**
+ * example of functional binding listener
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FunctionalBindingListener {
+
+	@Qualifier(ProgrammaticBindingNotifyCommandPublisher.OUTBOUND_BEAN_NAME)
+	private final SpringMessagePublisher springMessagePublisher;
+
+	/**
+	 * Consume {@link PostCreatedEvent} by functional way
+	 * and publish {@link NotifyToSubscribers} by programmatic way.
+	 */
+	@Bean
+	Consumer<PostCreatedEvent> toNotifyToSubscribers() {
+		return event -> {
+			log.info("[CONSUME][Functional][PostCreatedEvent] {}", event);
+
+			springMessagePublisher.publish(
+				new NotifyToSubscribers(event.getPostId())
+			);
+		};
+	}
+
+	/**
+	 * Consume {@link NotifyToSubscribers} by functional way
+	 */
+	@Bean
+	Consumer<NotifyToSubscribers> consumeNotifyToSubscribersCommand() {
+		return command -> log.info("[CONSUME][NotifyToSubscribers] {}", command);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/ProgrammaticBindingCommandListener.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/ProgrammaticBindingCommandListener.java
@@ -1,0 +1,115 @@
+package com.navercorp.eventeria.guide.boot.listener;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.messaging.SubscribableChannel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCommandHandler;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.ApplySearchIndex;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.RefreshPostRanking;
+import com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand.UpdateUserStatistic;
+import com.navercorp.eventeria.messaging.contract.cloudevents.converter.CloudEventToMessageConverter;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.InboundChannelBinder;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessageHandler;
+import com.navercorp.eventeria.messaging.spring.integration.dsl.MessageSubscriberIntegrationAdapter;
+import com.navercorp.eventeria.messaging.spring.integration.router.MessagePayloadTypeRouter;
+
+/**
+ * example of programmatic binding 'command' listener
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProgrammaticBindingCommandListener {
+
+	/**
+	 * bean name for SpringMessageHandler
+	 */
+	private static final String INBOUND_BEAN_NAME = "inbound-channel-after-post-command";
+
+	/**
+	 * binding name defined in application.yml
+	 */
+	private static final String INBOUND_KAFKA_CHANNEL_NAME = "inbound-kafka-channel-after-post-command";
+
+	private static final String ROUTER_NAME = "afterPostCreationCommandRouter";
+
+	private final InboundChannelBinder inboundChannelBinder;
+	private final AfterPostCommandHandler afterPostCommandHandler;
+
+	/**
+	 * inbound channel for receiving messages from messaging system (kafka)
+	 */
+	@Bean(INBOUND_KAFKA_CHANNEL_NAME)
+	SubscribableChannel inboundChannel() {
+		return requireNonNull(
+			inboundChannelBinder.getInboundChannel(INBOUND_KAFKA_CHANNEL_NAME)
+		);
+	}
+
+	/**
+	 * intermediate channel which receives transformed messages from messaging system,
+	 * and sends then to application
+	 */
+	@Bean(INBOUND_BEAN_NAME)
+	SpringMessageHandler messageHandler() {
+		return new SpringMessageHandler();
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #inboundChannel()} and {@link #messageHandler()}
+	 */
+	@Bean
+	IntegrationFlowAdapter inboundAfterPostCreationCommandIntegrationFlowAdapter(
+		@Qualifier(INBOUND_KAFKA_CHANNEL_NAME) SubscribableChannel inboundChannel,
+		CloudEventToMessageConverter cloudEventToMessageConverter,
+		@Qualifier(INBOUND_BEAN_NAME) SpringMessageHandler springMessageHandler
+	) {
+		return new MessageSubscriberIntegrationAdapter(
+			inboundChannel,
+			cloudEventToMessageConverter,
+			springMessageHandler
+		);
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #messageHandler()} and {@link #afterPostCreationCommandRouter()}
+	 */
+	@Bean
+	IntegrationFlow afterPostCreationCommandRouterIntegrationFlow(
+		@Qualifier(INBOUND_BEAN_NAME) SpringMessageHandler springMessageHandler,
+		@Qualifier(ROUTER_NAME) MessagePayloadTypeRouter postEventRouter
+	) {
+		return IntegrationFlow.from(springMessageHandler)
+			.route(postEventRouter)
+			.get();
+	}
+
+	@Bean(ROUTER_NAME)
+	MessagePayloadTypeRouter afterPostCreationCommandRouter() {
+		return MessagePayloadTypeRouter.register(INBOUND_BEAN_NAME)
+			.route(
+				UpdateUserStatistic.class,
+				afterPostCommandHandler::updateUserStatistic
+			)
+			.route(
+				RefreshPostRanking.class,
+				afterPostCommandHandler::refreshPostRanking
+			)
+			.route(
+				ApplySearchIndex.class,
+				afterPostCommandHandler::applySearchIndex
+			)
+			.done();
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/ProgrammaticBindingEventListener.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/listener/ProgrammaticBindingEventListener.java
@@ -1,0 +1,103 @@
+package com.navercorp.eventeria.guide.boot.listener;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.messaging.SubscribableChannel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent;
+import com.navercorp.eventeria.guide.boot.domain.PostEventHandler;
+import com.navercorp.eventeria.messaging.contract.cloudevents.converter.CloudEventToMessageConverter;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.InboundChannelBinder;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessageHandler;
+import com.navercorp.eventeria.messaging.spring.integration.dsl.MessageSubscriberIntegrationAdapter;
+import com.navercorp.eventeria.messaging.spring.integration.router.MessagePayloadTypeRouter;
+
+/**
+ * example of programmatic binding 'event' listener
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProgrammaticBindingEventListener {
+
+	/**
+	 * bean name for SpringMessageHandler
+	 */
+	private static final String INBOUND_BEAN_NAME = "inbound-channel-post-event";
+
+	/**
+	 * binding name defined in application.yml
+	 */
+	private static final String INBOUND_KAFKA_CHANNEL_NAME = "inbound-kafka-channel-post-event-programmatic";
+
+	private static final String ROUTER_NAME = "postEventRouter";
+
+	private final InboundChannelBinder inboundChannelBinder;
+
+	/**
+	 * inbound channel for receiving messages from messaging system (kafka)
+	 */
+	@Bean(INBOUND_KAFKA_CHANNEL_NAME)
+	SubscribableChannel inboundChannel() {
+		return requireNonNull(
+			inboundChannelBinder.getInboundChannel(INBOUND_KAFKA_CHANNEL_NAME)
+		);
+	}
+
+	/**
+	 * intermediate channel which receives transformed messages from messaging system,
+	 * and sends then to application
+	 */
+	@Bean(INBOUND_BEAN_NAME)
+	SpringMessageHandler messageHandler() {
+		return new SpringMessageHandler();
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #inboundChannel()} and {@link #messageHandler()}
+	 */
+	@Bean
+	IntegrationFlowAdapter inboundPostEventIntegrationFlowAdapter(
+		@Qualifier(INBOUND_KAFKA_CHANNEL_NAME) SubscribableChannel inboundChannel,
+		CloudEventToMessageConverter cloudEventToMessageConverter,
+		@Qualifier(INBOUND_BEAN_NAME) SpringMessageHandler springMessageHandler
+	) {
+		return new MessageSubscriberIntegrationAdapter(
+			inboundChannel,
+			cloudEventToMessageConverter,
+			springMessageHandler
+		);
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #messageHandler()} and {@link #postEventRouter}
+	 */
+	@Bean
+	IntegrationFlow postEventRouterIntegrationFlow(
+		@Qualifier(INBOUND_BEAN_NAME) SpringMessageHandler springMessageHandler,
+		@Qualifier(ROUTER_NAME) MessagePayloadTypeRouter postEventRouter
+	) {
+		return IntegrationFlow.from(springMessageHandler)
+			.route(postEventRouter)
+			.get();
+	}
+
+	@Bean(ROUTER_NAME)
+	MessagePayloadTypeRouter postEventRouter(
+		PostEventHandler postEventHandler
+	) {
+		return MessagePayloadTypeRouter.register(INBOUND_BEAN_NAME)
+			.route(PostCreatedEvent.class, postEventHandler::publishAfterPostCreatedCommands)
+			.done();
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingAfterPostCommandPublisher.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingAfterPostCommandPublisher.java
@@ -1,0 +1,77 @@
+package com.navercorp.eventeria.guide.boot.publisher;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.messaging.MessageChannel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.messaging.contract.cloudevents.converter.MessageToCloudEventConverter;
+import com.navercorp.eventeria.messaging.contract.cloudevents.header.CloudEventHeaderMapper;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.OutboundChannelBinder;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+import com.navercorp.eventeria.messaging.spring.integration.dsl.MessagePublisherIntegrationAdapter;
+
+/**
+ * example of programmatic binding 'command' publisher
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProgrammaticBindingAfterPostCommandPublisher {
+
+	/**
+	 * bean name for SpringMessagePublisher
+	 */
+	public static final String OUTBOUND_BEAN_NAME = "outbound-channel-after-post-command";
+
+	/**
+	 * binding name defined in application.yml
+	 */
+	private static final String OUTBOUND_KAFKA_CHANNEL_NAME = "outbound-kafka-channel-after-post-command";
+
+	private final OutboundChannelBinder outboundChannelBinder;
+
+	/**
+	 * outbound channel for publishing messages to messaging system (kafka)
+	 */
+	@Bean(OUTBOUND_KAFKA_CHANNEL_NAME)
+	MessageChannel outboundChannel() {
+		return requireNonNull(
+			outboundChannelBinder.getOutboundChannel(OUTBOUND_KAFKA_CHANNEL_NAME)
+		);
+	}
+
+	/**
+	 * intermediate channel which receives transformed messages from messaging system,
+	 * and sends then to application
+	 */
+	@Bean(OUTBOUND_BEAN_NAME)
+	SpringMessagePublisher messagePublisher() {
+		return new SpringMessagePublisher();
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #messagePublisher()} and {@link #outboundChannel()}
+	 */
+	@Bean
+	IntegrationFlowAdapter outboundAfterPostCreationCommandIntegrationFlowAdapter(
+		@Qualifier(OUTBOUND_KAFKA_CHANNEL_NAME) MessageChannel outboundChannel,
+		MessageToCloudEventConverter messageToCloudEventConverter,
+		CloudEventHeaderMapper cloudEventHeaderMapper,
+		@Qualifier(OUTBOUND_BEAN_NAME) SpringMessagePublisher springMessagePublisher
+	) {
+		return new MessagePublisherIntegrationAdapter(
+			springMessagePublisher,
+			messageToCloudEventConverter,
+			cloudEventHeaderMapper,
+			outboundChannel
+		);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingEventPublisher.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingEventPublisher.java
@@ -1,0 +1,77 @@
+package com.navercorp.eventeria.guide.boot.publisher;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.messaging.MessageChannel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.messaging.contract.cloudevents.converter.MessageToCloudEventConverter;
+import com.navercorp.eventeria.messaging.contract.cloudevents.header.CloudEventHeaderMapper;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.OutboundChannelBinder;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+import com.navercorp.eventeria.messaging.spring.integration.dsl.MessagePublisherIntegrationAdapter;
+
+/**
+ * example of programmatic binding 'event' publisher
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProgrammaticBindingEventPublisher {
+
+	/**
+	 * bean name for SpringMessagePublisher
+	 */
+	public static final String OUTBOUND_BEAN_NAME = "outbound-channel-post-event";
+
+	/**
+	 * binding name defined in application.yml
+	 */
+	private static final String OUTBOUND_KAFKA_CHANNEL_NAME = "outbound-kafka-channel-post-event";
+
+	private final OutboundChannelBinder outboundChannelBinder;
+
+	/**
+	 * outbound channel for publishing messages to messaging system (kafka)
+	 */
+	@Bean(OUTBOUND_KAFKA_CHANNEL_NAME)
+	MessageChannel outboundChannel() {
+		return requireNonNull(
+			outboundChannelBinder.getOutboundChannel(OUTBOUND_KAFKA_CHANNEL_NAME)
+		);
+	}
+
+	/**
+	 * intermediate channel which receives transformed messages from messaging system,
+	 * and sends then to application
+	 */
+	@Bean(OUTBOUND_BEAN_NAME)
+	SpringMessagePublisher messagePublisher() {
+		return new SpringMessagePublisher();
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #messagePublisher()} and {@link #outboundChannel()}
+	 */
+	@Bean
+	IntegrationFlowAdapter outboundPostEventIntegrationFlowAdapter(
+		@Qualifier(OUTBOUND_KAFKA_CHANNEL_NAME) MessageChannel outboundChannel,
+		MessageToCloudEventConverter messageToCloudEventConverter,
+		CloudEventHeaderMapper cloudEventHeaderMapper,
+		@Qualifier(OUTBOUND_BEAN_NAME) SpringMessagePublisher springMessagePublisher
+	) {
+		return new MessagePublisherIntegrationAdapter(
+			springMessagePublisher,
+			messageToCloudEventConverter,
+			cloudEventHeaderMapper,
+			outboundChannel
+		);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingNotifyCommandPublisher.java
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/java/com/navercorp/eventeria/guide/boot/publisher/ProgrammaticBindingNotifyCommandPublisher.java
@@ -1,0 +1,77 @@
+package com.navercorp.eventeria.guide.boot.publisher;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.messaging.MessageChannel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.navercorp.eventeria.messaging.contract.cloudevents.converter.MessageToCloudEventConverter;
+import com.navercorp.eventeria.messaging.contract.cloudevents.header.CloudEventHeaderMapper;
+import com.navercorp.eventeria.messaging.spring.cloud.stream.binding.OutboundChannelBinder;
+import com.navercorp.eventeria.messaging.spring.integration.channel.SpringMessagePublisher;
+import com.navercorp.eventeria.messaging.spring.integration.dsl.MessagePublisherIntegrationAdapter;
+
+/**
+ * example of programmatic binding 'command' listener
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProgrammaticBindingNotifyCommandPublisher {
+
+	/**
+	 * bean name for SpringMessagePublisher
+	 */
+	public static final String OUTBOUND_BEAN_NAME = "outbound-channel-notify-command";
+
+	/**
+	 * binding name defined in application.yml
+	 */
+	private static final String OUTBOUND_KAFKA_CHANNEL_NAME = "outbound-kafka-channel-notify-command";
+
+	private final OutboundChannelBinder outboundChannelBinder;
+
+	/**
+	 * outbound channel for publishing messages to messaging system (kafka)
+	 */
+	@Bean(OUTBOUND_KAFKA_CHANNEL_NAME)
+	MessageChannel outboundChannel() {
+		return requireNonNull(
+			outboundChannelBinder.getOutboundChannel(OUTBOUND_KAFKA_CHANNEL_NAME)
+		);
+	}
+
+	/**
+	 * intermediate channel which receives transformed messages from messaging system,
+	 * and sends then to application
+	 */
+	@Bean(OUTBOUND_BEAN_NAME)
+	SpringMessagePublisher messagePublisher() {
+		return new SpringMessagePublisher();
+	}
+
+	/**
+	 * configure flow between two channels,
+	 * {@link #messagePublisher()} and {@link #outboundChannel()}
+	 */
+	@Bean
+	IntegrationFlowAdapter outboundNotifyCommandIntegrationFlowAdapter(
+		@Qualifier(OUTBOUND_KAFKA_CHANNEL_NAME) MessageChannel outboundChannel,
+		MessageToCloudEventConverter messageToCloudEventConverter,
+		CloudEventHeaderMapper cloudEventHeaderMapper,
+		@Qualifier(OUTBOUND_BEAN_NAME) SpringMessagePublisher springMessagePublisher
+	) {
+		return new MessagePublisherIntegrationAdapter(
+			springMessagePublisher,
+			messageToCloudEventConverter,
+			cloudEventHeaderMapper,
+			outboundChannel
+		);
+	}
+}

--- a/guide-projects/spring-boot-eventeria-guide/src/main/resources/application.yml
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/resources/application.yml
@@ -1,0 +1,59 @@
+spring:
+  cloud:
+    function:
+      definition:
+        transformCloudEventToMessage|toNotifyToSubscribers;
+        transformMessageToCloudEvent;
+        transformCloudEventToMessage|consumeNotifyToSubscribersCommand;
+    stream:
+      function:
+        bindings:
+          transformCloudEventToMessage|toNotifyToSubscribers-in-0: inbound-kafka-channel-post-event-functional
+          transformCloudEventToMessage|consumeNotifyToSubscribersCommand-in-0: inbound-kafka-channel-notify-command-functional
+      kafka:
+        binder:
+          brokers: localhost:9092
+      bindings:
+        inbound-kafka-channel-post-event-programmatic:
+          group: post-programmatic
+          destination: ${topics.post-event}
+          consumer:
+            concurrency: 1
+            auto-startup: true
+        inbound-kafka-channel-post-event-functional:
+          group: post-functional
+          destination: ${topics.post-event}
+          consumer:
+            concurrency: 1
+            auto-startup: true
+            use-native-decoding: true # for custom headers/extensions of eventeria
+        inbound-kafka-channel-notify-command-functional:
+          group: notify-functional
+          destination: ${topics.notify-command}
+          consumer:
+            concurrency: 1
+            auto-startup: true
+            use-native-decoding: true # for custom headers/extensions of eventeria
+        inbound-kafka-channel-after-post-command:
+          group: after-post-programmatic
+          destination: ${topics.after-post-command}
+          consumer:
+            concurrency: 1
+            auto-startup: true
+        outbound-kafka-channel-post-event:
+          destination: ${topics.post-event}
+          producer:
+            partition-count: 2
+        outbound-kafka-channel-notify-command:
+          destination: ${topics.notify-command}
+          producer:
+            partition-count: 2
+        outbound-kafka-channel-after-post-command:
+          destination: ${topics.after-post-command}
+          producer:
+            partition-count: 2
+
+topics:
+  post-event: post-event
+  after-post-command: after-post-command
+  notify-command: notify-command

--- a/guide-projects/spring-boot-eventeria-guide/src/main/resources/application.yml
+++ b/guide-projects/spring-boot-eventeria-guide/src/main/resources/application.yml
@@ -3,7 +3,6 @@ spring:
     function:
       definition:
         transformCloudEventToMessage|toNotifyToSubscribers;
-        transformMessageToCloudEvent;
         transformCloudEventToMessage|consumeNotifyToSubscribersCommand;
     stream:
       function:

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,5 @@ include "eventeria-timer-spring-integration"
 include "eventeria-messaging-timer-spring-redis"
 include "spring-boot-eventeria"
 include "eventeria-fake-spring-cloud-stream-binder-kafka"
+
+include "guide-projects:spring-boot-eventeria-guide"

--- a/spring-boot-eventeria/src/main/java/com/navercorp/spring/boot/eventeria/support/FunctionalBindingSupports.java
+++ b/spring-boot-eventeria/src/main/java/com/navercorp/spring/boot/eventeria/support/FunctionalBindingSupports.java
@@ -1,0 +1,42 @@
+package com.navercorp.spring.boot.eventeria.support;
+
+import java.util.function.Function;
+
+import io.cloudevents.CloudEvent;
+
+import com.navercorp.eventeria.messaging.contract.Message;
+import com.navercorp.eventeria.messaging.contract.cloudevents.serializer.CloudEventMessageReaderWriter;
+import com.navercorp.eventeria.messaging.filter.CloudEventFilter;
+
+/**
+ * Utilities for supporting functional binding of spring-cloud-stream
+ */
+public final class FunctionalBindingSupports {
+
+	private static final CloudEventFilter ACCEPT_ALL_FILTER = cloudEvent -> true;
+
+	private FunctionalBindingSupports() {
+		throw new IllegalStateException("utility class");
+	}
+
+	public static Function<org.springframework.messaging.Message<byte[]>, Message> convertToMessage(
+		CloudEventMessageReaderWriter converter
+	) {
+		return convertToMessage(converter, ACCEPT_ALL_FILTER);
+	}
+
+	public static Function<org.springframework.messaging.Message<byte[]>, Message> convertToMessage(
+		CloudEventMessageReaderWriter converter,
+		CloudEventFilter cloudEventFilter
+	) {
+		return message -> {
+			CloudEvent cloudEvent = converter.deserialize(message.getPayload());
+
+			if (!cloudEventFilter.accept(cloudEvent)) {
+				return null;
+			}
+
+			return converter.convert(cloudEvent);
+		};
+	}
+}


### PR DESCRIPTION
related #27

- add spring-boot-eventeria applications in `guide-projects` directory
- introduce `FunctionalBindingSupports`

tested by executing below command.

```
> curl -H "Content-Type:application/json" -XPOST localhost:8080/posts/1 -d '{"id":1, "writerId":"testWriter", "content":"Hello, World!"}'
```

and application logs are following.

```
2024-06-25T14:26:31.959+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.b.l.FunctionalBindingListener    : [CONSUME][Functional][PostCreatedEvent] PostCreatedEvent(super=AbstractEvent{id=ca593e8f-339d-4bd9-8ce0-deda678ff3df, sourceId='1', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post/1, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post/1', correlationId=null, operationId='null', occurrenceTime=2024-06-25T05:26:31.909731Z, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post/1, messagecategory=MESSAGE,EVENT,DOMAIN_EVENT, typealias=com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent}}, postId=1, writerId=testWriter)
2024-06-25T14:26:31.960+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.boot.domain.PostEventHandler     : [CONSUME][Programmatic][PostCreatedEvent] PostCreatedEvent(super=AbstractEvent{id=ca593e8f-339d-4bd9-8ce0-deda678ff3df, sourceId='1', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post/1, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post/1', correlationId=null, operationId='null', occurrenceTime=2024-06-25T05:26:31.909731Z, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post/1, messagecategory=MESSAGE,EVENT,DOMAIN_EVENT, typealias=com.navercorp.eventeria.guide.boot.domain.PostCreatedEvent}}, postId=1, writerId=testWriter)
2024-06-25T14:26:31.969+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.b.l.FunctionalBindingListener    : [CONSUME][NotifyToSubscribers] AbstractCommand{id=df502285-5b90-41c5-b789-c03bcc9fce8d, sourceId='null', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post', correlationId=null, operationId='null', occurrenceTime=null, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post, messagecategory=MESSAGE,COMMAND, typealias=com.navercorp.eventeria.guide.boot.domain.AfterPostCreationCommand$NotifyToSubscribers}}
2024-06-25T14:26:31.970+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.b.d.AfterPostCommandHandler      : [CONSUME][UpdateUserStatistic] AbstractCommand{id=e97fab64-247d-4b62-b3ae-8b5daa474aeb, sourceId='null', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post', correlationId=null, operationId='null', occurrenceTime=null, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post, messagecategory=MESSAGE,COMMAND}}
2024-06-25T14:26:31.976+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.b.d.AfterPostCommandHandler      : [CONSUME][RefreshPostRanking] AbstractCommand{id=12baced4-e53e-417d-a0db-b2bb325655eb, sourceId='null', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post', correlationId=null, operationId='null', occurrenceTime=null, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post, messagecategory=MESSAGE,COMMAND}}
2024-06-25T14:26:31.980+09:00  INFO 15042 --- [container-0-C-1] c.n.e.g.b.d.AfterPostCommandHandler      : [CONSUME][ApplySearchIndex] AbstractCommand{id=254d7333-011c-436e-9247-0f7653e3bb70, sourceId='null', sourceVersion=null, source=/com.navercorp.eventeria.guide.boot.domain.Post, dataSchema=null, subject='null', partitionKey='/com.navercorp.eventeria.guide.boot.domain.Post', correlationId=null, operationId='null', occurrenceTime=null, extensions={partitionkey=/com.navercorp.eventeria.guide.boot.domain.Post, messagecategory=MESSAGE,COMMAND}}
```