### PR TITLE
Bump up dependencies versions

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-springBootVersion=3.2.1
+springBootVersion=3.3.2

--- a/eventeria-messaging-json-jackson/src/main/java/com/navercorp/eventeria/messaging/jackson/header/JacksonCloudEventHeaderMapper.java
+++ b/eventeria-messaging-json-jackson/src/main/java/com/navercorp/eventeria/messaging/jackson/header/JacksonCloudEventHeaderMapper.java
@@ -18,16 +18,16 @@
 
 package com.navercorp.eventeria.messaging.jackson.header;
 
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 
 import com.navercorp.eventeria.messaging.header.DefaultCloudEventHeaderMapper;
 
 /**
- * A extended implementation to configure 'content-type' header as {@link JsonFormat#CONTENT_TYPE}
+ * A extended implementation to configure 'content-type' header as {@link ContentType#JSON}
  */
 public class JacksonCloudEventHeaderMapper extends DefaultCloudEventHeaderMapper {
 	public JacksonCloudEventHeaderMapper() {
-		super(EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE));
+		super(EventFormatProvider.getInstance().resolveFormat(ContentType.JSON));
 	}
 }

--- a/eventeria-messaging-json-jackson/src/main/java/com/navercorp/eventeria/messaging/jackson/serializer/JacksonCloudEventSerializer.java
+++ b/eventeria-messaging-json-jackson/src/main/java/com/navercorp/eventeria/messaging/jackson/serializer/JacksonCloudEventSerializer.java
@@ -18,17 +18,17 @@
 
 package com.navercorp.eventeria.messaging.jackson.serializer;
 
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 
 import com.navercorp.eventeria.messaging.serializer.DefaultCloudEventSerializer;
 
 /**
  * A implementation of serializer/deserializer between {@link io.cloudevents.CloudEvent} and byte array<br/>
- * using {@link JsonFormat}.
+ * using {@link ContentType#JSON}.
  */
 public final class JacksonCloudEventSerializer extends DefaultCloudEventSerializer {
 	public JacksonCloudEventSerializer() {
-		super(EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE));
+		super(EventFormatProvider.getInstance().resolveFormat(ContentType.JSON));
 	}
 }

--- a/eventeria-messaging-kafka/src/test/java/com/navercorp/eventeria/messaging/kafka/CloudEventKafkaTest.java
+++ b/eventeria-messaging-kafka/src/test/java/com/navercorp/eventeria/messaging/kafka/CloudEventKafkaTest.java
@@ -45,9 +45,9 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.domains.Domain;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.message.Encoding;
 import io.cloudevents.core.provider.EventFormatProvider;
-import io.cloudevents.jackson.JsonFormat;
 import io.cloudevents.kafka.CloudEventDeserializer;
 import io.cloudevents.kafka.CloudEventSerializer;
 import kafka.server.KafkaConfig;
@@ -108,7 +108,7 @@ class CloudEventKafkaTest {
 		producerProps.put(CloudEventSerializer.ENCODING_CONFIG, Encoding.STRUCTURED);
 		producerProps.put(
 			CloudEventSerializer.EVENT_FORMAT_CONFIG,
-			EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+			EventFormatProvider.getInstance().resolveFormat(ContentType.JSON)
 		);
 
 		try (KafkaProducer<String, CloudEvent> producer = new KafkaProducer<>(producerProps)) {
@@ -131,7 +131,7 @@ class CloudEventKafkaTest {
 
 			records.forEach(rec -> {
 				rec.headers().headers("content-type").iterator().forEachRemaining(it ->
-					assertThat(new String(it.value(), StandardCharsets.UTF_8)).isEqualTo(JsonFormat.CONTENT_TYPE)
+					assertThat(new String(it.value(), StandardCharsets.UTF_8)).isEqualTo(ContentType.JSON.value())
 				);
 
 				Message message = cloudEventToMessageConverter.convert(rec.value());

--- a/eventeria-messaging-spring/src/main/java/com/navercorp/eventeria/messaging/spring/converter/SpringCloudEventMessageConverter.java
+++ b/eventeria-messaging-spring/src/main/java/com/navercorp/eventeria/messaging/spring/converter/SpringCloudEventMessageConverter.java
@@ -29,6 +29,7 @@ import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.core.format.ContentType;
 
 import com.navercorp.eventeria.messaging.contract.cloudevents.serializer.CloudEventSerializerDeserializer;
 
@@ -41,7 +42,7 @@ public class SpringCloudEventMessageConverter extends AbstractMessageConverter {
 	public SpringCloudEventMessageConverter(CloudEventSerializerDeserializer cloudEventSerializerDeserializer) {
 		super(
 			Arrays.asList(
-				new MimeType("application", "cloudevents+json"),
+				MimeType.valueOf(ContentType.JSON.value()),
 				MimeTypeUtils.APPLICATION_JSON
 			)
 		);

--- a/eventeria-messaging/src/test/java/com/navercorp/eventeria/messaging/serializer/DefaultCloudEventSerializerTest.java
+++ b/eventeria-messaging/src/test/java/com/navercorp/eventeria/messaging/serializer/DefaultCloudEventSerializerTest.java
@@ -27,10 +27,10 @@ import net.jqwik.api.lifecycle.BeforeTry;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.SpecVersion;
+import io.cloudevents.core.format.ContentType;
 import io.cloudevents.core.provider.EventFormatProvider;
 import io.cloudevents.core.v1.CloudEventV1;
 import io.cloudevents.jackson.JsonCloudEventData;
-import io.cloudevents.jackson.JsonFormat;
 
 import com.navercorp.eventeria.messaging.contract.Message;
 import com.navercorp.eventeria.messaging.contract.cloudevents.converter.CloudEventToMessageConverter;
@@ -52,7 +52,7 @@ import com.navercorp.eventeria.messaging.typealias.CloudEventMessageTypeAliasMap
 
 class DefaultCloudEventSerializerTest {
 	private final DefaultCloudEventSerializer sut = new DefaultCloudEventSerializer(
-		EventFormatProvider.getInstance().resolveFormat(JsonFormat.CONTENT_TYPE)
+		EventFormatProvider.getInstance().resolveFormat(ContentType.JSON)
 	);
 	private final JacksonMessageSerializer messageSerializer = new JacksonMessageSerializer();
 	private MessageToCloudEventConverter messageToCloudEventConverter;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 jqwikVersion=1.7.0
-springCloudVersion=2023.0.2
-cloudEventVersion=2.5.0
+springCloudVersion=2023.0.3
+cloudEventVersion=4.0.1


### PR DESCRIPTION
- spring-boot: 3.2.1 -> 3.3.2
- spring-cloud: 2023.0.2 (4.1.2) -> 2023.0.3 (4.1.3)
    - https://github.com/spring-cloud/spring-cloud-stream/compare/v4.1.2...v4.1.3
- cloudevents: 2.5.0 -> 4.0.1
    - https://github.com/cloudevents/sdk-java/compare/2.5.0...v4.0.1